### PR TITLE
Add autocomplete support via omelette

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ lwsm restore my-session
 lwsm restore --closeAllOpenWindows
 ```
 
+
+### Command-line completion:
+```
+# Automatically install command-line completion
+lwsm --setupCompletion
+# Generate command-line completion code for bash and zsh shells for manual installation
+lwsm --completion
+# Generate command-line completion code for fish shell for manual installation
+lwsm --completion-fish
+```
+Command-line completion implemented by [omelette](https://github.com/f/omelette), so you may refer it's README to check file where completion code will be added on automatic install.
+Restart your shell after automatic install to apply changes.
+
+
 ## Known Quirks
 In order to resize and move the windows the X window manager is used. Unfortunately it has some bugs:  
 * Windows moved to the very left of the screen will always be off by some pixels in Unity

--- a/cmd.js
+++ b/cmd.js
@@ -1,6 +1,21 @@
 #!/usr/bin/env node
 'use strict';
 const base = require('./lib/index');
+const omelette = require('omelette');
+
+// There should be no output to stdin until completion.init()
+const sessionList = Object.keys(base.getSessions());
+
+let completion = omelette('lwsm');
+completion.tree({
+  save: sessionList,
+  restore: sessionList
+});
+completion.init();
+
+if (~process.argv.indexOf('--setupCompletion')) {
+  completion.setupShellInitFile()
+}
 
 function catchInputHandlerErr(err) {
   console.error('Input Handler Error: ', err);

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,6 +69,7 @@ module.exports = {
   saveSession,
   removeSession,
   restoreSession,
+  getSessions,
   x11Helper: metaW.x11Helper,
   getConnectedDisplaysId: metaW.getConnectedDisplaysId,
   resetCfg: () => {
@@ -99,6 +100,11 @@ function catchGenericErr(err) {
   console.error('Generic Error in Main Handler', err);
   throw err;
 }
+
+function getSessions() {
+  return db.allSync()
+}
+
 
 // MAIN FUNCTIONS
 // --------------

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "jfs": "^0.2.6",
     "promise-waterfall": "^0.1.0",
-    "x11": "^2.2.1"
+    "x11": "^2.2.1",
+    "omelette": "nkovshov/omelette"
   },
   "nexe": {
     "input": "./cmd.js",


### PR DESCRIPTION
There is a draft of implementing completion(#4).
`omelette` dependency points to forked repository in my account since there is a error in official, need to be changed after fix.