### PR TITLE
Prevent an error when no windows with an unknown executable exist in windowList

### DIFF
--- a/lib/metaWrapper.js
+++ b/lib/metaWrapper.js
@@ -141,11 +141,15 @@ function addParsedExecutableFilesFromWmClassNames(windowList) {
     });
 
     // TODO replace waterfall with regular exec
-    waterfall(promises)
-      .then(() => {
-        fulfill(windowList);
-      })
-      .catch(reject);
+    if(promises.length){
+      waterfall(promises)
+        .then(() => {
+          fulfill(windowList);
+        })
+        .catch(reject);
+    }else{
+      fulfill(windowList);
+    }
   }).catch(catchGenericErr);
 }
 


### PR DESCRIPTION
A similar thing is caught within getActiveWindowList() but was missing from addParsedExecutableFilesFromWmClassNames() 