### PR TITLE
add slack app name and new folder for desktop files

### DIFF
--- a/lib/defaultConfig.js
+++ b/lib/defaultConfig.js
@@ -14,7 +14,8 @@ module.exports = {
     "sun-awt-X11-XFramePeer.jetbrains-idea": "jetbrains-idea.desktop",
     "VirtualBox.VirtualBox": "virtualbox.desktop",
     "Telegram.TelegramDesktop": "telegram-desktop_telegramdesktop.desktop",
-    "keepassxc.keepassxc": "keepassxc_keepassxc.desktop"
+    "keepassxc.keepassxc": "keepassxc_keepassxc.desktop",
+    "slack.Slack": "com.slack.Slack.desktop"
   },
   "WM_CLASS_EXCLUSIONS": [
     "N/A",
@@ -46,7 +47,8 @@ module.exports = {
     "/usr/local/share/applications",
     "/usr/share/app-install",
     "{home}/.config/autostart/",
-    "/var/lib/snapd/desktop/applications"
+    "/var/lib/snapd/desktop/applications",
+    "/var/lib/flatpak/app"
   ],
   "CMD": {
     "GET_DISPLAY_ID": "xrandr --query | grep '[^s]connected '",


### PR DESCRIPTION
1- finding the **slack** desktop app desktop file was difficult as the app name is unusual
2- on Fedora silverblue 29, all applications from **dl.flathub.org** are stored in  `/var/lib/flatpak/app`