### PR TITLE
Update defaultConfig.ts

### DIFF
--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -53,6 +53,7 @@ export const DEFAULT_CFG = {
         "{home}/.config/autostart/",
         "/var/lib/snapd/desktop/applications",
         "/var/lib/flatpak/app",
+        "/var/lib/flatpak/exports/share/applications",
         "/snap/bin"
     ]
 };


### PR DESCRIPTION
Flatpak location on Fedora 31

Before:
```
$ lwsm save
findDesktopFile cant find file; searched patterns []
Generic Error in Meta Wrapper findDesktopFile cant find file; searched patterns undefined
Input Handler Error:  No input for desktop file path for window "slack.Slack". Please fix this manually in config file for this session in ~/.lwsm/{currentSessionName}.json
 undefined
SAVED SESSION: DEFAULT
```

After:
```
$ lwsm save
SAVED SESSION: DEFAULT
```