### PR TITLE
Fixed bug when moving applications to third or higher workspaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -553,16 +553,24 @@ async function _restoreWindowPositions(
   savedWindowList: WinObj[]
 ): Promise<void> {
   const promises = [];
-  savedWindowList.forEach(win => {
-    promises.push(restoreWindowPosition(win));
-    promises.push(moveToWorkspace(win.windowId, win.wmCurrentDesktopNr));
+  let last_desktop_nr = 0;
+  savedWindowList = savedWindowList.sort((a, b) => {
+    if (a.wmCurrentDesktopNr > b.wmCurrentDesktopNr) return 1;
+    if (a.wmCurrentDesktopNr < b.wmCurrentDesktopNr) return -1;
+    return 0;
   });
 
-  for (const promise of promises) {
-    try {
-      await promise;
-    } catch (e) {
-      _catchGenericErr(e);
+  for (const win of savedWindowList) {
+    promises.push(restoreWindowPosition(win));
+    promises.push(moveToWorkspace(win.windowId, win.wmCurrentDesktopNr));
+    if (win.wmCurrentDesktopNr != last_desktop_nr) {
+      for (const promise of promises) {
+        try {
+          await promise;
+        } catch (e) {
+          _catchGenericErr(e);
+        }
+      }
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,7 +563,7 @@ async function _restoreWindowPositions(
   for (const win of savedWindowList) {
     promises.push(restoreWindowPosition(win));
     promises.push(moveToWorkspace(win.windowId, win.wmCurrentDesktopNr));
-    if (win.wmCurrentDesktopNr != last_desktop_nr) {
+    if ( (win.wmCurrentDesktopNr != last_desktop_nr) || (win == savedWindowList.slice(-1)[0])) {
       for (const promise of promises) {
         try {
           await promise;
@@ -571,6 +571,8 @@ async function _restoreWindowPositions(
           _catchGenericErr(e);
         }
       }
+      last_desktop_nr = win.wmCurrentDesktopNr;
+      promises.length = 0
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,16 +554,23 @@ async function _restoreWindowPositions(
 ): Promise<void> {
   const promises = [];
   let last_desktop_nr = 0;
-  savedWindowList = savedWindowList.sort((a, b) => {
-    if (a.wmCurrentDesktopNr > b.wmCurrentDesktopNr) return 1;
-    if (a.wmCurrentDesktopNr < b.wmCurrentDesktopNr) return -1;
-    return 0;
+  
+  // Sort the window objects based on which workspace they are locate,
+  // so the windows can be moved workspace by workspace
+  // This is needed because the window manager just creates an aditional workspace when 
+  // the previous one has some window on it.
+  savedWindowList = savedWindowList.concat().sort((a, b) => {
+    return a.wmCurrentDesktopNr - b.wmCurrentDesktopNr;
   });
 
   for (const win of savedWindowList) {
     promises.push(restoreWindowPosition(win));
     promises.push(moveToWorkspace(win.windowId, win.wmCurrentDesktopNr));
-    if ( (win.wmCurrentDesktopNr != last_desktop_nr) || (win == savedWindowList.slice(-1)[0])) {
+
+    // The promises are not executed until the last item is reached or 
+    // the desktop_nr is different from the previous entry and which case
+    // the app waits for those to finish before continuing the process
+    if ( (win.wmCurrentDesktopNr !== last_desktop_nr) || (win === savedWindowList.slice(-1)[0])) {
       for (const promise of promises) {
         try {
           await promise;


### PR DESCRIPTION
Fixed #62 

The bug was occurring because it was trying to move the windows to an workspace that did not exist yet.

To fix that I ordered the windows objects based on its workspace location, then moved them in that order. The Window Manager creates an additional workspace ever time a window is moved to the last one. The promises for each workspace were executed separately to make sure the Window Manager created the new workspace.

I also tried to set the _NET_NUMBER_OF_DESKTOPS to the number of desktops it would require, but it did not work. The documentation says the Window Manager may or may not honor the request.

I had to disable prettier, because it was making a lot of changes on the code.
It is my first contribution to a opensource project, so let me know if I should have done it differently.
Thanks for the project, it is awesome.