### PR TITLE
Add input arguments to the applications

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -461,7 +461,7 @@ async function _startSessionPrograms(
     })
     .map(win => {
       win.instancesStarted += 1;
-      return startProgram(win.executableFile, win.desktopFilePath);
+      return startProgram(win.executableFile, win.desktopFilePath, win.executableArgs);
     });
 
   await Promise.all(promises);

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,17 +210,12 @@ function restoreSession(
             );
             return;
           }
-          return getActiveWindowListFlow();
+          return;
         })
-        .then(currentWindowList => {
-          return _startSessionPrograms(savedWindowList, currentWindowList);
+        .then( () => {
+          return _startAndWaitPrograms(savedWindowList);
         })
         .then(() => {
-          // gets current window list by itself and returns the updated variant
-          return _waitForAllAppsToStart(savedWindowList);
-        })
-        .then((updatedCurrentWindowList: WinObj[]) => {
-          _updateWindowIds(savedWindowList, updatedCurrentWindowList);
           return _restoreWindowPositions(savedWindowList);
         })
         .then(() => {
@@ -465,6 +460,117 @@ async function _startSessionPrograms(
     });
 
   await Promise.all(promises);
+}
+
+
+// This function is necessary to make possible sending custom arguments to applications to start,
+// making sure it will keep track of which windows correspond to which instance of the applications
+async function _startAndWaitPrograms(
+  windowList: WinObj[],
+){
+
+  // Clear the windowIds from the window objects
+  windowList.forEach(win=>{
+    win.windowId = null;
+    win.windowIdDec = null;
+  })
+
+  // Get the windowIds of all Ids that were previously opened in order to
+  // avoid these windows from being used isntead of the newly created windows
+  // (necessary for windows with custom input arguments)
+  var activeWindows = await getActiveWindowListFlow()
+  var blackWinIdList = activeWindows.map( win => win.windowId)
+
+  // Match all the previously opened windows with the windows that do not have
+  // custom arguments (in this case, no blacklist needed)
+  await _matchWindows(windowList, false, [])
+
+  var windowsNotStarted = windowList.filter(win => win.windowId === null);
+  var windowStarted =  windowList.filter(win => win.windowId !== null);
+  var windowsToStart = _getWindowsToStart(windowsNotStarted, windowStarted);
+
+  let totalTimeWaited = 0;
+  // Runs the loop until all windows have been opened or time limit is over
+  while (windowList.find(win => win.windowId === null)){
+    totalTimeWaited += CFG.POLL_ALL_APPS_STARTED_INTERVAL;
+    if (totalTimeWaited > CFG.POLL_ALL_MAX_TIMEOUT * 10) {
+      console.error("POLL_ALL_MAX_TIMEOUT reached");
+      windowList.filter(win => win.windowId === null).forEach(e =>{
+        console.log('Unable to start: ',e.wmClassName)
+      })
+      break
+    }
+
+    let promises = windowsToStart.map(
+      win => {
+        startProgram(win.executableFile, win.desktopFilePath, win.executableArgs)
+      }
+    );
+    await Promise.all(promises)
+
+    // Try to match newly started windows, the black list is needed to avoid matching
+    // windows that have custom arguments with windows oppened before running lwsm
+    await _matchWindows( windowList, true, blackWinIdList)
+    // Update the lists with the windows not to be started yet, the windows to be started next
+    // and the ones that already have the command to start sent
+    windowsNotStarted = windowsNotStarted.filter(winNotStarted => !(windowsToStart.find(winToStart => winToStart === winNotStarted)));
+    windowStarted = windowStarted.concat(windowsToStart);
+    windowsToStart = _getWindowsToStart(windowsNotStarted, windowStarted);
+  }
+
+  windowList.forEach(win => {win.windowIdDec = parseInt(win.windowId, 16)});
+}
+
+
+// Get, from windowList, all the windows that can be started without the risk of
+// mixing same application windows with different arguments. The others will have to wait for the
+// previous windows to start, before the command can be issued
+function _getWindowsToStart(
+  windowList: WinObj[],
+  windowsStarted: WinObj[]
+){
+  var windowsToStart = [];
+  for (var win of windowList){
+    let shouldAdd = true;
+    // If another instance of the same application with different input arguments
+    // is in the list of windows to start, then the current one should not be added
+    windowsToStart.forEach( winToRun =>{
+      if ((win.executableFile ===  winToRun.executableFile) &&
+          (win.executableArgs !==  winToRun.executableArgs)){
+            shouldAdd = false;
+          }
+      }
+    )
+    // If another instance of the same application is in the list of windows that 
+    // have been sent command to start, but still don't have a windowId, the current one should not be added
+    if (windowsStarted.find(winStarted => (winStarted.windowId === null && winStarted.wmClassName === win.wmClassName)) ){
+      shouldAdd = false;
+    }
+    if (!win.windowId && shouldAdd) {windowsToStart.push(win)};
+  }
+  return windowsToStart;
+}
+
+
+// Match the windows that have been opened already to the windows on windowList 
+async function _matchWindows(
+  windowList: WinObj[],
+  includeExecsWithArgs: boolean,
+  blackWinIdList: String[]
+){
+  var activeWindows = await getActiveWindowListFlow()
+  // Remove the active windows that already have a window assigned on windowList
+  // and the ones that are on the black list
+  activeWindows = activeWindows.filter(actWin => !windowList.find(win => win.windowId === actWin.windowId));
+  activeWindows = activeWindows.filter(actWin => !blackWinIdList.find(windowId => windowId === actWin.windowId));
+
+  for (var win of windowList.filter(win => win.windowId === null)){
+    let activeWindowMatch = activeWindows.find(actWin => actWin.wmClassName == win.wmClassName);
+    if (activeWindowMatch && (!win.executableArgs || win.executableArgs === '' || includeExecsWithArgs)){
+      win.windowId = activeWindowMatch.windowId;
+      activeWindows = activeWindows.filter(e => e !== activeWindowMatch);
+    }
+  }
 }
 
 function _getNumberOfInstancesToRun(

--- a/src/model.ts
+++ b/src/model.ts
@@ -16,6 +16,7 @@ export interface WinObj extends WinObjIdOnly {
   height: number;
   simpleName: string;
   executableFile: string;
+  executableArgs: string;
   desktopFilePath?: string;
   instancesStarted?: number;
 }

--- a/src/otherCmd.ts
+++ b/src/otherCmd.ts
@@ -98,7 +98,7 @@ export function startProgram(
     const parsedCmd = parseCmdArgs(executableFile);
     cmd = parsedCmd[0];
     args = parsedCmd[1];
-    args = args.concat([executableArgs]);
+    args = args.concat(executableArgs.split(' '));
   }
 
   return new Promise(fulfill => {

--- a/src/otherCmd.ts
+++ b/src/otherCmd.ts
@@ -79,7 +79,8 @@ export async function getAdditionalMetaDataForWin(
 // TODO prettify args structure
 export function startProgram(
   executableFile: string,
-  desktopFilePath: string
+  desktopFilePath: string,
+  executableArgs: string
 ): Promise<void> {
   IS_DEBUG &&
     console.log("DEBUG: startProgram():", executableFile, desktopFilePath);
@@ -87,9 +88,10 @@ export function startProgram(
   let cmd;
   let args = [];
   if (desktopFilePath) {
+    executableArgs = (executableArgs) ? ` ${executableArgs}`: "";
     cmd = `awk`;
     args.push(
-      '/^Exec=/ {sub("^Exec=", ""); gsub(" ?%[cDdFfikmNnUuv]", ""); exit system($0)}'
+      `/^Exec=/ {sub("^Exec=", ""); gsub(" ?%[cDdFfikmNnUuv]", "${executableArgs}"); exit system($0)}`
     );
     args.push(desktopFilePath);
   } else {

--- a/src/otherCmd.ts
+++ b/src/otherCmd.ts
@@ -98,6 +98,7 @@ export function startProgram(
     const parsedCmd = parseCmdArgs(executableFile);
     cmd = parsedCmd[0];
     args = parsedCmd[1];
+    args = args.concat([executableArgs]);
   }
 
   return new Promise(fulfill => {


### PR DESCRIPTION
**Problem:**
I felt that would be nice to have the possibility to have my browser, file explorer or VScode to open with the tabs I want, or in the folder I want, when restoring a session.
Saving that information automatically when saving a session looked like a hard tasks, and even harder to make it generic for all applications (maybe impossible).

**Solution:**
The workaround I found for these would be to enable user to manually put arguments on the json files to be passed as input arguments when starting the applications. Adding this functionality itself was not a problem, but an other issue came up:
When the session has more than one instance of the same application, it was impossible to tell which window of the application was opened with which input arguments (I could not find a way, at least).

To overcome that, bigger changes had to be done on the code. I created a function "_startAndWaitPrograms" that would, in case there were instances of the same applications with different input arguments, wait for the window of each instance of the application to open, before starting the other one. The new code is commented, in order to explain exactly how it is done.

**How to use:**
I tested the code with different applications,. To make use of the new functionality the field "executableArgs" has to be added to the json file.

For google chrome you can add:
	  `"executableArgs": "--new-window gmail.com google.com" `

For firefox:
`	  "executableArgs": "--new-window gmail.com"`
or (if you want to open more than one tab):
`	  "executableArgs": " gmail.com google.com"`

For nautilus:
	  `"executableArgs": "/home/rodrigo/Desktop"`

For Vscode:
	  `"executableArgs": "/home/rodrigo/Desktop"`

**Concerns regarding the code:**
- There are some functions that are not being used anymore, as I adapted them into the "_startAndWaitPrograms" function. Should I remove them?
- As the new function starts, waits and updates the windowId at the same time, I used the CFG.POLL_ALL_MAX_TIMEOUT value multiplied by 10. Should I create a new constant in config for that? Would that be a good value?
- I understand that this changes require changes on the user usage and some changes on the structure of the code, so I understand if you decide not to incorporate them.
- I didn't exactly understand the timeout set on "_waitForAllAppsToStart", so I didn't add it to the new function. Should I add it?

Best regards,