### PR TITLE
Search Flatpak applications under {home}

### DIFF
--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -56,6 +56,7 @@ export const DEFAULT_CFG = {
     "/var/lib/snapd/desktop/applications",
     "/var/lib/flatpak/app",
     "/var/lib/flatpak/exports/share/applications",
+    "{home}/.local/share/flatpak/exports/share/applications",
     "/snap/bin"
   ]
 };


### PR DESCRIPTION
Add `{home}/.local/share/flatpak/exports/share/applications` for Flatpak applications under the user home directory. On Pop_OS! 20.10, Flatpak applications from the Pop!_Shop are installed here instead of `/var/lib/flatpak/`. I imagine it would be popular enough to use as a default.