### PR TITLE
Add support for Microsoft Edge Apps

### DIFF
--- a/src/metaWrapper.ts
+++ b/src/metaWrapper.ts
@@ -159,7 +159,9 @@ function _isChromeApp(fileName) {
 function _parseChromeAppDesktopFileName(fileName) {
   return new Promise((resolve, reject) => {
     // we wan't to search from desktop files only
-    const locateStr = fileName.replace("crx_", "*") + "*.desktop";
+    // chrome wm class uses prefix crx_ (one underscore)
+    // edge wm class uses prefix crx__ (two underscores)
+    const locateStr = fileName.replace(/crx__?/, "*") + "*.desktop";
     findDesktopFile(locateStr)
       .then(resolve)
       .catch(reject);


### PR DESCRIPTION
# Description

Adds support for Microsoft Edge Apps. Microsoft Edge prefixes `WMClass` with `crx__` whereas Google Chrome uses `crx_`, one less underscore. I've modified `_parseChromeAppDesktopFileName` to use a regex replace with the second underscore being optional.

## Issues Resolved

Fixes #83

## Check List

- [x] New functionality includes testing.

I tested saving and restoring of simultaneous Google Chrome, Microsoft Edge and other windows work as expected.
